### PR TITLE
Do not fail whole installation process when component is already installed

### DIFF
--- a/deployments/gitea.go
+++ b/deployments/gitea.go
@@ -201,7 +201,8 @@ func (k Gitea) Deploy(c *kubernetes.Cluster, ui *ui.UI, options kubernetes.Insta
 		metav1.GetOptions{},
 	)
 	if err == nil {
-		return errors.New("Namespace " + GiteaDeploymentID + " present already")
+		ui.Exclamation().Msg("Namespace " + GiteaDeploymentID + " already present, skipping installation")
+		return nil
 	}
 
 	ui.Note().KeeplineUnder(1).Msg("Deploying Gitea...")

--- a/deployments/quarks.go
+++ b/deployments/quarks.go
@@ -145,7 +145,8 @@ func (k Quarks) Deploy(c *kubernetes.Cluster, ui *ui.UI, options kubernetes.Inst
 		metav1.GetOptions{},
 	)
 	if err == nil {
-		return errors.New("Namespace " + QuarksDeploymentID + " present already")
+		ui.Exclamation().Msg("Namespace " + QuarksDeploymentID + " already present, skipping installation")
+		return nil
 	}
 
 	ui.Note().KeeplineUnder(1).Msg("Deploying Quarks...")

--- a/deployments/registry.go
+++ b/deployments/registry.go
@@ -144,7 +144,8 @@ func (k Registry) Deploy(c *kubernetes.Cluster, ui *ui.UI, options kubernetes.In
 		metav1.GetOptions{},
 	)
 	if err == nil {
-		return errors.New("Namespace " + RegistryDeploymentID + " present already")
+		ui.Exclamation().Msg("Namespace " + RegistryDeploymentID + " already present, skipping installation")
+		return nil
 	}
 
 	ui.Note().KeeplineUnder(1).Msg("Deploying Registry...")

--- a/deployments/tekton.go
+++ b/deployments/tekton.go
@@ -263,7 +263,8 @@ func (k Tekton) Deploy(c *kubernetes.Cluster, ui *ui.UI, options kubernetes.Inst
 		metav1.GetOptions{},
 	)
 	if err == nil {
-		return errors.New("Namespace " + TektonDeploymentID + " present already")
+		ui.Exclamation().Msg("Namespace " + TektonDeploymentID + " already present, skipping installation")
+		return nil
 	}
 
 	ui.Note().KeeplineUnder(1).Msg("Deploying Tekton...")

--- a/deployments/workloads.go
+++ b/deployments/workloads.go
@@ -110,7 +110,8 @@ func (k Workloads) Deploy(c *kubernetes.Cluster, ui *ui.UI, options kubernetes.I
 		metav1.GetOptions{},
 	)
 	if err == nil {
-		return errors.New("Namespace " + WorkloadsDeploymentID + " present already")
+		ui.Exclamation().Msg("Namespace " + WorkloadsDeploymentID + " already present, skipping installation")
+		return nil
 	}
 
 	ui.Note().KeeplineUnder(1).Msg("Deploying Workloads...")


### PR DESCRIPTION
Helpful when just one component fails so you do not need to uninstall all