### PR TITLE
Increase the size for default PVC for a pipeline

### DIFF
--- a/embedded-files/tekton/triggers.yaml
+++ b/embedded-files/tekton/triggers.yaml
@@ -35,7 +35,7 @@ spec:
                 - ReadWriteOnce
               resources:
                 requests:
-                  storage: 1Gi
+                  storage: 2Gi
         params:
         - name: image
           value: registry.carrier-registry/apps/$(tt.params.appname)


### PR DESCRIPTION
When pipeline's task is building an image, 1GB might not be enough